### PR TITLE
include hydiomatic.hy into setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'hydiomatic': ['*.hy'],
         'hydiomatic.rulesets': ['*.hy'],
     },
+    scripts = ['bin/hydiomatic.hy'],
     author="Gergely Nagy",
     author_email="algernon@madhouse-project.org",
     long_description="""Static code analyser for Hy""",


### PR DESCRIPTION
This change includes hydiomatic.hy in setup.py
After installing the package, user will be able to call hydiomatic.hy
